### PR TITLE
[Mentor 'Sign Up' pop-up] the text "Already have a Space2Study account? Log In" doesn't correspond the requirements

### DIFF
--- a/src/constants/translations/en/signup.json
+++ b/src/constants/translations/en/signup.json
@@ -7,8 +7,8 @@
   "and": "and",
   "googleButton": "Sign up with Google",
   "continue": "or continue",
-  "haveAccount": "Already have a tutor account?",
-  "joinUs": "Login!",
+  "haveAccount": "Already have a Space2Study account?",
+  "joinUs": "Log In!",
   "confirmEmailTitle": "Your email address needs to be verified",
   "confirmEmailMessage": "We sent a confirmation email to: ",
   "confirmEmailDesc": " Check your email and click on the confirmation button to continue."


### PR DESCRIPTION
Changed the text