### PR TITLE
Add unit test for QuestionEditor component

### DIFF
--- a/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
+++ b/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
@@ -1,0 +1,78 @@
+import { expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import QuestionEditor from '~/components/question-editor/QuestionEditor'
+
+const handleInputChange = vi.fn()
+const handleNonInputValueChange = vi.fn()
+const onCancel = vi.fn()
+const onEdit = vi.fn()
+const onSave = vi.fn()
+
+const props = {
+  handleInputChange,
+  handleNonInputValueChange,
+  onCancel,
+  onEdit,
+  onSave,
+  isQuizQuestion: true
+}
+
+describe('QuestionEditor component with open answer type', () => {
+  const openQuestionData = {
+    type: 'openAnswer',
+    text: 'Sample question text',
+    openAnswer: 'Sample open answer',
+    answers: []
+  }
+
+  const openQuestionProps = {
+    ...props,
+    data: openQuestionData
+  }
+
+  beforeEach(() => {
+    render(<QuestionEditor {...openQuestionProps} />)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render question input field', () => {
+    const questionInput = screen.getByLabelText('questionPage.question')
+    expect(questionInput).toBeInTheDocument()
+  })
+
+  it('should render open answer field', () => {
+    const openAnswerInput = screen.getByLabelText('questionPage.answer')
+    expect(openAnswerInput).toBeInTheDocument()
+  })
+
+  it('should change question type', () => {
+    const selectElement = screen.getByTestId('app-select')
+    fireEvent.click(selectElement)
+    fireEvent.change(selectElement, {
+      target: { value: 'oneAnswer' }
+    })
+    expect(handleNonInputValueChange).toHaveBeenCalled()
+  })
+
+  it('should change question and answer input fields', async () => {
+    const questionInput = screen.getByLabelText('questionPage.question')
+    await userEvent.type(questionInput, 'New question')
+    expect(handleInputChange).toHaveBeenCalledWith('text')
+
+    const answerInput = screen.getByLabelText('questionPage.answer')
+    await userEvent.type(answerInput, 'New answer')
+    expect(handleInputChange).toHaveBeenCalledWith('openAnswer')
+  })
+
+  it('should click on edit title and category', async () => {
+    const moreVertIcon = screen.getByTestId('MoreVertIcon')
+    await userEvent.click(moreVertIcon)
+    const editIcon = screen.getByTestId('EditIcon')
+    await userEvent.click(editIcon)
+    expect(onEdit).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Following checks implemented: 

it should renders question input field
it should renders a open answer
it should change question type
it should change question and answer input fields
it should click on edit title and category
![tests pass](https://github.com/user-attachments/assets/65ed7a04-12be-4be7-9b0c-3a868984995b)

### Use fireEvent because Select component from MUI has pointer-events: none.
![pointer event](https://github.com/user-attachments/assets/b7ed6dc9-119a-4239-9aec-ae5bc81f8668)
